### PR TITLE
Update curl to 7.40.0 to be able to use TLSv1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,9 @@ openssl:
 	fi
 
 libcurl:
-	wget http://curl.haxx.se/download/curl-7.32.0.tar.gz
-	tar xzf curl-7.32.0.tar.gz
-	cd curl-7.32.0 ;\
+	wget http://curl.haxx.se/download/curl-7.40.0.tar.gz
+	tar xzf curl-7.40.0.tar.gz
+	cd curl-7.40.0 ;\
 	./configure --prefix=$(PREFIX) PKG_CONFIG_PATH=$(PREFIX)/lib/pkgconfig:$(PREFIX)/lib64/pkgconfig ;\
 	make install
 


### PR DESCRIPTION
As the eID Service allows PAOS connection only with TLSv1.2, current curl 7.32.0 release has to be moved to 7.40.0 release.
The TLSv1.2 support was added with CURL 7.34.0 release.