### PR TITLE
curl_my_trace: use CURLINFO HEADER&DATA OUT&IN for debuging

### DIFF
--- a/eIDClientCore/lib/eIDClientConnection/eIDClientConnection.c
+++ b/eIDClientCore/lib/eIDClientConnection/eIDClientConnection.c
@@ -159,21 +159,21 @@ static int curl_my_trace(CURL *handle, curl_infotype type, char *data, size_t si
 		default: /* in case a new one is introduced to shock us */   
 			return 0;
 
-		/*case CURLINFO_HEADER_OUT:   
+		case CURLINFO_HEADER_OUT:   
 			text = "=> Send header";   
 			break;   
 		case CURLINFO_DATA_OUT:   
 			text = "=> Send data";   
-			break;*/
+			break;
 		case CURLINFO_SSL_DATA_OUT:   
 			text = "=> Send SSL data";
 			break;   
-		/*case CURLINFO_HEADER_IN:   
+		case CURLINFO_HEADER_IN:   
 			text = "<= Recv header";   
 			break;   
 		case CURLINFO_DATA_IN:   
 			text = "<= Recv data";   
-			break;*/
+			break;
 		case CURLINFO_SSL_DATA_IN:   
 			text = "<= Recv SSL data";   
 			break;   


### PR DESCRIPTION
Usage of CURLINFO_HEADER_OUT / CURLINFO_DATA_OUT and CURLINFO_HEADER_IN / CURLINFO_DATA_IN to see the payload in debug sessions.
With that I can clearly see, that [Issue #45](https://github.com/BeID-lab/eIDClientCore/issues/45) gets the expected 302 Location with tcTokenURL, but then it is lost during getting bufResult