### PR TITLE
eIDClientConnectionStartHttp() needs enum GetHttpHeader at four lines

### DIFF
--- a/eIDClientCore/bin/Test_nPAClientLib/Test_nPAClientLib.cpp
+++ b/eIDClientCore/bin/Test_nPAClientLib/Test_nPAClientLib.cpp
@@ -444,7 +444,7 @@ int getSamlResponse2(std::string & response)
 #if SAML_VERSION == NO_SAML
 	connection_status = eIDClientConnectionStartHttp(&connection, strRefresh.c_str(), NULL, NULL, DontGetHttpHeader, DontFollowHttpRedirect);
 #else
-	connection_status = eIDClientConnectionStartHttp(&connection, strRefresh.c_str(), NULL, NULL, DontGetHttpHeader, DontFollowHttpRedirect);
+	connection_status = eIDClientConnectionStartHttp(&connection, strRefresh.c_str(), NULL, NULL, GetHttpHeader, DontFollowHttpRedirect);
 #endif
 
 	if (connection_status != EID_CLIENT_CONNECTION_ERROR_SUCCESS) {
@@ -494,7 +494,7 @@ int getSamlResponse2(std::string & response)
 	memset(sz, 0, READ_BUFFER);
 	sz_len = READ_BUFFER;
 
-	connection_status = eIDClientConnectionStartHttp(&connection, strResult.c_str(), NULL, NULL, DontGetHttpHeader, DontFollowHttpRedirect);
+	connection_status = eIDClientConnectionStartHttp(&connection, strResult.c_str(), NULL, NULL, GetHttpHeader, DontFollowHttpRedirect);
 	if (connection_status != EID_CLIENT_CONNECTION_ERROR_SUCCESS) {
 		return connection_status;
 	}
@@ -781,7 +781,7 @@ int getAuthenticationParams2(const char *const SP_URL,
 	size_t sz_len = sizeof sz;
 
 	//Send Form with selected Attributes
-	connection_status = eIDClientConnectionStartHttp(&connection, SP_URL, NULL, NULL, DontGetHttpHeader, DontFollowHttpRedirect);
+	connection_status = eIDClientConnectionStartHttp(&connection, SP_URL, NULL, NULL, GetHttpHeader, DontFollowHttpRedirect);
 	if (connection_status != EID_CLIENT_CONNECTION_ERROR_SUCCESS) {
 		printf("%s:%d Error\n", __FILE__, __LINE__);
 		return connection_status;
@@ -816,7 +816,7 @@ int getAuthenticationParams2(const char *const SP_URL,
 	//strResult = str_replace("https", "http", strResult);
 
 	//Get AuthnRequest
-	connection_status = eIDClientConnectionStartHttp(&connection, strResult.c_str(), NULL, NULL, DontGetHttpHeader, DontFollowHttpRedirect);
+	connection_status = eIDClientConnectionStartHttp(&connection, strResult.c_str(), NULL, NULL, GetHttpHeader, DontFollowHttpRedirect);
 	if (connection_status != EID_CLIENT_CONNECTION_ERROR_SUCCESS) {
 		printf("%s:%d Error\n", __FILE__, __LINE__);
 		return connection_status;


### PR DESCRIPTION
Comparing with source code from March the eIDClientConnectionStartHttp() was set there WITH "GetHttpHeader".
After changing the four lines in current Version I got back working the code and [Issue #45](https://github.com/BeID-lab/eIDClientCore/issues/45) is solved